### PR TITLE
Fix for June PPP DLC

### DIFF
--- a/SpacePOIExtraInfo/src/SpacePOIExtraInfo.cs
+++ b/SpacePOIExtraInfo/src/SpacePOIExtraInfo.cs
@@ -178,7 +178,6 @@ namespace SpacePOIExtraInfo
             {
                 if (artifactConfigurator == null)
                 {
-                    Debug.Log("[SpacePOIExtraInfo] Skipping artifact UI; no ArtifactPOIConfigurator present.");
                     return;
                 }
                 // Add UI changes if they weren't set yet or the info panel got set to a new instance somehow

--- a/SpacePOIExtraInfo/src/SpacePOIExtraInfo.cs
+++ b/SpacePOIExtraInfo/src/SpacePOIExtraInfo.cs
@@ -176,6 +176,11 @@ namespace SpacePOIExtraInfo
                 ArtifactPOIConfigurator artifactConfigurator,
                 CollapsibleDetailContentPanel spacePOIPanel)
             {
+                if (artifactConfigurator == null)
+                {
+                    Debug.Log("[SpacePOIExtraInfo] Skipping artifact UI; no ArtifactPOIConfigurator present.");
+                    return;
+                }
                 // Add UI changes if they weren't set yet or the info panel got set to a new instance somehow
                 if (!ReferenceEquals(SpacePOIInfoPanel, __instance))
                 {


### PR DESCRIPTION
The new space POIs don't have artifacts at all, which is what caused the crash. This small change fixes this.